### PR TITLE
feat: add Supabase client and environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SUPABASE_URL=your_supabase_url
+SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Generated files
 assets/brickbox-icon.png
+
+# Local development environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ The visual identity uses the base64-encoded icon in `assets/brickbox-icon.b64`. 
 
 ## Tech Stack Overview
 See [STACK.md](STACK.md) for the MVP tooling and the path to scale.
+
+## Local Development
+1. Copy `.env.example` to `.env`.
+2. Add your Supabase project URL and anonymous key to `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
+3. The `.env` file is ignored by git and used by the Supabase client in `src/lib/supabaseClient.ts`.

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- initialize Supabase client with environment variables
- add `.env.example` and ignore local `.env`
- document environment variable setup for local development

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a781f2ed248328b319bcda0632e294