### PR TITLE
Add Python requirements and streamline CI install

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flake8
+pytest

--- a/scripts/decode_icon.py
+++ b/scripts/decode_icon.py
@@ -10,10 +10,12 @@ ASSET_DIR = Path(__file__).resolve().parents[1] / "assets"
 B64_PATH = ASSET_DIR / "brickbox-icon.b64"
 PNG_PATH = ASSET_DIR / "brickbox-icon.png"
 
+
 def main() -> None:
     data = base64.b64decode(B64_PATH.read_text())
     PNG_PATH.write_bytes(data)
     print(f"Decoded {B64_PATH} -> {PNG_PATH}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add `requirements.txt` for lint and test dependencies
- simplify workflow to install dependencies from requirements
- tidy icon decoder script spacing for flake8 compliance

## Testing
- `flake8 .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a781f3ea7883289a8b26ff3df11b10