### PR TITLE
Add test for decode_icon PNG output

### DIFF
--- a/scripts/decode_icon.py
+++ b/scripts/decode_icon.py
@@ -10,10 +10,12 @@ ASSET_DIR = Path(__file__).resolve().parents[1] / "assets"
 B64_PATH = ASSET_DIR / "brickbox-icon.b64"
 PNG_PATH = ASSET_DIR / "brickbox-icon.png"
 
+
 def main() -> None:
     data = base64.b64decode(B64_PATH.read_text())
     PNG_PATH.write_bytes(data)
     print(f"Decoded {B64_PATH} -> {PNG_PATH}")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_decode_icon.py
+++ b/tests/test_decode_icon.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import scripts.decode_icon as decode_icon  # noqa: E402
+
+
+def test_decode_icon_writes_png(tmp_path, monkeypatch):
+    """Decode the base64 icon and ensure PNG is produced in tmp directory."""
+    src_b64 = (
+        Path(__file__).resolve().parents[1] / "assets" / "brickbox-icon.b64"
+    )
+    tmp_b64 = tmp_path / "icon.b64"
+    tmp_b64.write_text(src_b64.read_text())
+    tmp_png = tmp_path / "icon.png"
+    monkeypatch.setattr(decode_icon, "B64_PATH", tmp_b64)
+    monkeypatch.setattr(decode_icon, "PNG_PATH", tmp_png)
+    decode_icon.main()
+    assert tmp_png.exists()
+    assert tmp_png.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")


### PR DESCRIPTION
## Summary
- verify the decode_icon script outputs a PNG from the base64 file using a temporary directory
- tidy decode_icon spacing to satisfy flake8

## Testing
- `python -m flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a781f8bbf48328817beee3ae1fc26b