### PR TITLE
Generate app icon from base64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # Generated files
-assets/brickbox-icon.png
+app/icon.png

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 BrickBox is the modern vault for comic collectors—track runs, tag keys, map continuity, and watch market moves without losing the culture.
 
 ## Design Theme
-The visual identity uses the base64-encoded icon in `assets/brickbox-icon.b64`. Generate the PNG with `python scripts/decode_icon.py` (or `base64 -d assets/brickbox-icon.b64 > assets/brickbox-icon.png`) and apply the theme’s dark slate background `#111419`, brick red accents `#6A2A29`, and light ivory text `#F5E9D5`.
+The visual identity uses the base64-encoded icon in `assets/brickbox-icon.b64`. After cloning the repository, run `python scripts/decode_icon.py` (or `base64 -d assets/brickbox-icon.b64 > app/icon.png`) to generate `app/icon.png` and apply the theme’s dark slate background `#111419`, brick red accents `#6A2A29`, and light ivory text `#F5E9D5`.
 
 ## Tech Stack Overview
 See [STACK.md](STACK.md) for the MVP tooling and the path to scale.

--- a/scripts/decode_icon.py
+++ b/scripts/decode_icon.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
 """Decode the base64 BrickBox icon into a PNG file.
 
-Reads assets/brickbox-icon.b64 and writes assets/brickbox-icon.png.
+Reads assets/brickbox-icon.b64 and writes app/icon.png.
 """
 import base64
 from pathlib import Path
 
-ASSET_DIR = Path(__file__).resolve().parents[1] / "assets"
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ASSET_DIR = ROOT_DIR / "assets"
 B64_PATH = ASSET_DIR / "brickbox-icon.b64"
-PNG_PATH = ASSET_DIR / "brickbox-icon.png"
+APP_DIR = ROOT_DIR / "app"
+PNG_PATH = APP_DIR / "icon.png"
 
 def main() -> None:
+    APP_DIR.mkdir(parents=True, exist_ok=True)
     data = base64.b64decode(B64_PATH.read_text())
     PNG_PATH.write_bytes(data)
     print(f"Decoded {B64_PATH} -> {PNG_PATH}")


### PR DESCRIPTION
## Summary
- remove committed icon and ignore generated `app/icon.png`
- decode base64 icon into `app/icon.png`
- document running the decode script after cloning

## Testing
- `python scripts/decode_icon.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7958b5efc8328b2a400e1ba05ce42