### PR TITLE
feat: add Dockerfile and document usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# --- Backend build stage --------------------------------------------------
+FROM python:3.11-slim AS backend
+WORKDIR /srv
+
+# Copy backend source and assets
+COPY scripts scripts
+COPY assets assets
+
+# Generate any derived assets (e.g. icon.png)
+RUN python scripts/decode_icon.py
+
+# --- Frontend build stage -------------------------------------------------
+FROM node:20-alpine AS frontend
+WORKDIR /app
+
+# Copy frontend sources and install/build if package.json exists
+COPY . .
+RUN if [ -f package.json ]; then npm ci && npm run build; else echo "No package.json, skipping frontend build"; fi
+
+# --- Runtime stage --------------------------------------------------------
+FROM python:3.11-slim
+WORKDIR /srv
+
+# Bring in backend files and built frontend assets
+COPY --from=backend /srv /srv
+COPY --from=frontend /app/.next ./app/.next
+
+EXPOSE 3000
+CMD ["python", "-m", "http.server", "3000"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ The visual identity uses the base64-encoded icon in `assets/brickbox-icon.b64`. 
 ## Tech Stack Overview
 See [STACK.md](STACK.md) for the MVP tooling and the path to scale.
 
+## Docker
+
+Build the multi-stage image and run the server locally:
+
+```sh
+docker build -t brickbox .
+docker run --rm -p 3000:3000 brickbox
+```
+
 ## License
 
 BrickBox is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- create multi-stage Dockerfile that builds backend assets and frontend build output
- document Docker build and run commands

## Testing
- `pytest -q`
- `docker build -t brickbox .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a95504348328846fbd298642ac70