### PR TITLE
Handle missing or invalid icon base64

### DIFF
--- a/scripts/decode_icon.py
+++ b/scripts/decode_icon.py
@@ -4,6 +4,8 @@
 Reads assets/brickbox-icon.b64 and writes app/icon.png.
 """
 import base64
+import binascii
+import logging
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -15,7 +17,20 @@ PNG_PATH = APP_DIR / "icon.png"
 
 def main() -> None:
     APP_DIR.mkdir(parents=True, exist_ok=True)
-    data = base64.b64decode(B64_PATH.read_text())
+
+    try:
+        b64_text = B64_PATH.read_text()
+    except FileNotFoundError:
+        logging.error("Base64 icon file not found: %s", B64_PATH)
+        return
+
+    try:
+        normalized = "".join(b64_text.split())
+        data = base64.b64decode(normalized, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        logging.error("Malformed base64 data in %s: %s", B64_PATH, exc)
+        return
+
     PNG_PATH.write_bytes(data)
     print(f"Decoded {B64_PATH} -> {PNG_PATH}")
 

--- a/tests/test_decode_icon.py
+++ b/tests/test_decode_icon.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import logging
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -18,3 +19,28 @@ def test_decode_icon_writes_png(tmp_path, monkeypatch):
     decode_icon.main()
     assert tmp_png.exists()
     assert tmp_png.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_missing_b64_logs_error(tmp_path, monkeypatch, caplog):
+    """Log an error when the base64 icon file is missing."""
+    missing_b64 = tmp_path / "missing.b64"
+    tmp_png = tmp_path / "icon.png"
+    monkeypatch.setattr(decode_icon, "B64_PATH", missing_b64)
+    monkeypatch.setattr(decode_icon, "PNG_PATH", tmp_png)
+    with caplog.at_level(logging.ERROR):
+        decode_icon.main()
+    assert "Base64 icon file not found" in caplog.text
+    assert not tmp_png.exists()
+
+
+def test_malformed_b64_logs_error(tmp_path, monkeypatch, caplog):
+    """Log an error when the base64 icon data is invalid."""
+    bad_b64 = tmp_path / "icon.b64"
+    bad_b64.write_text("not base64!")
+    tmp_png = tmp_path / "icon.png"
+    monkeypatch.setattr(decode_icon, "B64_PATH", bad_b64)
+    monkeypatch.setattr(decode_icon, "PNG_PATH", tmp_png)
+    with caplog.at_level(logging.ERROR):
+        decode_icon.main()
+    assert "Malformed base64 data" in caplog.text
+    assert not tmp_png.exists()


### PR DESCRIPTION
## Summary
- log descriptive errors when `brickbox-icon.b64` is missing or malformed
- normalize base64 content before decoding
- add tests for missing and malformed base64 icon data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7a95541bc8328939a59e36d11a69c