### PR TITLE
feat: link token and store

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,28 @@ export default function Home() {
     <main style={{ padding: 24 }}>
       <h1>BrickBox</h1>
       <p>Comic/Manga Collector hub — coming soon 🚀</p>
+      <p>
+        <a
+          href="https://brickbox.printify.me/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Visit the BrickBox store
+        </a>
+      </p>
+      <p>
+        <a
+          href="https://brickbox.printify.me/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="https://pmlvtovpbfpbrjaexvqh.supabase.co/storage/v1/object/public/Public/brickbox_token.png"
+            alt="BrickBox token"
+            style={{ maxWidth: 200 }}
+          />
+        </a>
+      </p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show link to BrickBox store and token image on landing page

## Testing
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8f1f55c4832889ae4fc7595834a6