### PR TITLE
Add BBX token and social pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,32 @@
+import Link from 'next/link';
+
 export const metadata = {
   title: 'BrickBox',
   description: 'Comic/Manga Collector hub — coming soon 🚀',
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <nav style={{ display: 'flex', gap: 16, padding: 16 }}>
+          <Link href="/">Home</Link>
+          <Link href="/token">Token</Link>
+          <Link href="/social">Social</Link>
+          <a
+            href="https://brickbox.printify.me/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Shop
+          </a>
+        </nav>
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,26 +4,8 @@ export default function Home() {
       <h1>BrickBox</h1>
       <p>Comic/Manga Collector hub — coming soon 🚀</p>
       <p>
-        <a
-          href="https://brickbox.printify.me/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Visit the BrickBox store
-        </a>
-      </p>
-      <p>
-        <a
-          href="https://brickbox.printify.me/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <img
-            src="https://pmlvtovpbfpbrjaexvqh.supabase.co/storage/v1/object/public/Public/brickbox_token.png"
-            alt="BrickBox token"
-            style={{ maxWidth: 200 }}
-          />
-        </a>
+        Use the navigation above to visit the shop, view the BBX token, or
+        connect on social media.
       </p>
     </main>
   );

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -1,0 +1,41 @@
+export const metadata = {
+  title: 'Social Links',
+  description: 'Find BrickBox across the web.',
+};
+
+export default function SocialPage() {
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Connect with BrickBox</h1>
+      <ul>
+        <li>
+          <a
+            href="https://x.com/dayfuhh?s=21"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Twitter
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://m.twitch.tv/dayfah/home"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Twitch
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www.tiktok.com/@dayfah"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            TikTok
+          </a>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/app/token/metadata.ts
+++ b/app/token/metadata.ts
@@ -1,0 +1,16 @@
+export const bbxMetadata = {
+  name: 'BrickBox Token',
+  symbol: 'BBX',
+  description:
+    'Utility token of BrickBox — boosts, discounts, gating, and tips across BrickBox apps and partner shops.',
+  image:
+    'https://pmlvtovpbfpbrjaexvqh.supabase.co/storage/v1/object/public/Public/brickbox_token.png',
+  external_url: 'https://brickbox.printify.me/',
+  attributes: [
+    { trait_type: 'Project', value: 'BrickBox' },
+    { trait_type: 'Utility', value: 'Boosts, Discounts, Gating, Tipping' },
+    { trait_type: 'Chain', value: 'Solana Token-2022' },
+  ],
+} as const;
+
+export type BBXMetadata = typeof bbxMetadata;

--- a/app/token/page.tsx
+++ b/app/token/page.tsx
@@ -1,0 +1,41 @@
+import { bbxMetadata } from './metadata';
+
+export const metadata = {
+  title: 'BBX Token',
+  description: 'Details about the BrickBox utility token.',
+};
+
+export default function TokenPage() {
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>
+        {bbxMetadata.name} ({bbxMetadata.symbol})
+      </h1>
+      <p>{bbxMetadata.description}</p>
+      <p>
+        <img
+          src={bbxMetadata.image}
+          alt={bbxMetadata.name}
+          style={{ maxWidth: 200 }}
+        />
+      </p>
+      <p>
+        <a
+          href={bbxMetadata.external_url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {bbxMetadata.external_url}
+        </a>
+      </p>
+      <h2>Attributes</h2>
+      <ul>
+        {bbxMetadata.attributes.map((attr) => (
+          <li key={attr.trait_type}>
+            <strong>{attr.trait_type}:</strong> {attr.value}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add navigation with links to token, social, and shop
- introduce BBX token metadata and page
- add social page linking to Twitter, Twitch, and TikTok

## Testing
- `npm test`
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae9a08c4ec83288cc8eff7027e1c8f