### PR TITLE
docs: add TikTok link to stack and social page

### DIFF
--- a/STACK.md
+++ b/STACK.md
@@ -12,7 +12,7 @@ This document outlines the concrete tools and services to make BrickBox real.  I
 ### App Frontend
 - **Mobile** – React Native via Expo for rapid iteration, OTA updates, push and camera access.
 - **UI kit** – Tamagui or React Native Paper styled with the BrickBox palette.
-- **Web** – Optional marketing and read‑only feed using Next.js on Vercel.
+- **Web** – Optional marketing and read‑only feed using Next.js on Vercel, linking to the [TikTok profile](https://www.tiktok.com/@dayfaa?_t=ZP-8zDjhuOz98p&_r=1).
 
 ### Backend & Data
 - **Primary backend** – Supabase (Postgres, Auth, RLS, Storage, Realtime).
@@ -121,4 +121,4 @@ This document outlines the concrete tools and services to make BrickBox real.  I
 - **Automation** – n8n (cloud) + Telegram Bot API.
 - **Security** – Cloudflare (DNS/WAF), Doppler (secrets).
 - **Docs/PM** – Notion + Linear.
-- **Marketing site** – Next.js on Vercel.
+- **Marketing site** – Next.js on Vercel with a link to the [TikTok profile](https://www.tiktok.com/@dayfaa?_t=ZP-8zDjhuOz98p&_r=1).

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -28,7 +28,7 @@ export default function SocialPage() {
         </li>
         <li>
           <a
-            href="https://www.tiktok.com/@dayfah"
+            href="https://www.tiktok.com/@dayfaa?_t=ZP-8zDjhuOz98p&_r=1"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Summary
- document TikTok profile on the Vercel-hosted marketing site
- update social links page with new TikTok URL

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aead5bee148328a1f8cedd782de254