### PR TITLE
Add dark theme styling for BrickBox app

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,20 @@
+html, body {
+  padding: 0;
+  margin: 0;
+  background-color: #121212;
+  color: #e5e5e5;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+a {
+  color: #8ab4f8;
+}
+
+nav a {
+  color: #e5e5e5;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import './globals.css';
 
 export const metadata = {
   title: 'BrickBox',
@@ -13,7 +14,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <nav style={{ display: 'flex', gap: 16, padding: 16 }}>
+        <nav
+          style={{
+            display: 'flex',
+            gap: 16,
+            padding: 16,
+            backgroundColor: '#1f1f1f',
+          }}
+        >
           <Link href="/">Home</Link>
           <Link href="/token">Token</Link>
           <Link href="/social">Social</Link>


### PR DESCRIPTION
## Summary
- import new global stylesheet to apply dark theme
- set darker navigation bar and link colors for easier viewing

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeaee620e88328952f0b1050d536f5