### PR TITLE
Add minimal Vercel config for Next.js build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "framework": "nextjs",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "git": { "deploymentEnabled": { "preview": true, "production": true } },
+  "ignoreCommand": "echo 'skip external apps'; exit 0"
+}


### PR DESCRIPTION
## Summary
- limit Vercel deployments to the Next.js app by adding a minimal `vercel.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afc29c284c832899b24b2a03c07094