### PR TITLE
chore: exclude archived code from TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     "**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "web-archive"
   ]
 }


### PR DESCRIPTION
## Summary
- ignore archived `web-archive` directory in TypeScript config to avoid missing module errors

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afcf4649c48328a9d1f83e91823fe7