### PR TITLE
Use default BRICK mint when env var missing

### DIFF
--- a/app/perks/page.tsx
+++ b/app/perks/page.tsx
@@ -3,8 +3,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { PhantomConnect } from '../../components/wallet/PhantomConnect';
 import { hasMint } from '../../lib/solana';
+import { bbxMetadata } from '../token/metadata';
 
-const MINT = process.env.NEXT_PUBLIC_BRICK_TOKEN_MINT || '';
+const MINT = process.env.NEXT_PUBLIC_BRICK_TOKEN_MINT || bbxMetadata.mint;
 
 export default function PerksPage() {
   const [pubkey, setPubkey] = useState<string | null>(null);
@@ -27,7 +28,6 @@ export default function PerksPage() {
   return (
     <div className="card">
       <h2>Perks (Token-gated)</h2>
-      {!MINT && <div className="small">Set <code>NEXT_PUBLIC_BRICK_TOKEN_MINT</code> in Vercel env to enable holder checks.</div>}
       <div style={{display:'flex', gap:12, alignItems:'center', marginTop: 8}}>
         <PhantomConnect onConnected={onConnected} />
       </div>

--- a/app/token/metadata.ts
+++ b/app/token/metadata.ts
@@ -1,6 +1,7 @@
 export const bbxMetadata = {
   name: 'BrickBox Token',
   symbol: 'BBX',
+  mint: 'C2zw5LJuJu6jpf84325zrGARwrarN8SrCTg5E12FNg3A',
   description:
     'Utility token of BrickBox — boosts, discounts, gating, and tips across BrickBox apps and partner shops.',
   image:

--- a/app/token/page.tsx
+++ b/app/token/page.tsx
@@ -6,10 +6,8 @@ import { bbxMetadata } from './metadata';
 
 export default function TokenPage() {
   const [pubkey, setPubkey] = useState<string | null>(null);
-  const mint = process.env.NEXT_PUBLIC_BRICK_TOKEN_MINT;
-  const buyUrl = mint
-    ? `https://jup.ag/swap/SOL-${mint}`
-    : bbxMetadata.external_url;
+  const mint = process.env.NEXT_PUBLIC_BRICK_TOKEN_MINT || bbxMetadata.mint;
+  const buyUrl = `https://jup.ag/swap/SOL-${mint}`;
 
   return (
     <main style={{ padding: 24 }}>


### PR DESCRIPTION
## Summary
- Provide BBX token mint in metadata for shared use
- Default to metadata mint when `NEXT_PUBLIC_BRICK_TOKEN_MINT` isn't set

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afd4daede4832887a563c9873adca6