### PR TITLE
Add dynamic Twitch live embed

### DIFF
--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,0 +1,15 @@
+import TwitchEmbed from '@/components/TwitchEmbed';
+
+export const metadata = {
+  title: 'Live',
+  description: 'Watch the live Twitch stream',
+};
+
+export default function LivePage() {
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Live on Twitch</h1>
+      <TwitchEmbed />
+    </main>
+  );
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -14,6 +14,7 @@ export default function NavBar() {
       <Link href="/">Home</Link>
       <Link href="/token">Token</Link>
       <Link href="/social">Social</Link>
+      <Link href="/live">Live</Link>
       <a href="https://brickbox.printify.me/" target="_blank" rel="noopener noreferrer">
         Shop
       </a>

--- a/components/TwitchEmbed.tsx
+++ b/components/TwitchEmbed.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function TwitchEmbed() {
+  const [parent, setParent] = useState<string | null>(null);
+
+  useEffect(() => {
+    setParent(window.location.hostname);
+  }, []);
+
+  if (!parent) return null;
+
+  return (
+    <iframe
+      src={`https://player.twitch.tv/?channel=dayfah&parent=${parent}`}
+      height="480"
+      width="720"
+      allowFullScreen
+    ></iframe>
+  );
+}


### PR DESCRIPTION
## Summary
- add TwitchEmbed component that derives parent domain from window.location
- create live page to host Twitch stream and link from nav bar

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b023fbfbdc8328915479bd4b58a591