### PR TITLE
Apply cohesive tech styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,20 +1,89 @@
+:root {
+  --color-bg: #121212;
+  --color-text: #e5e5e5;
+  --color-muted: #a1a1aa;
+  --color-accent: #00c2ff;
+  --color-nav-bg: #1f1f1f;
+  --color-card-bg: #141416;
+  --border-color: #1f2937;
+  --font-main: 'Roboto Mono', monospace;
+}
+
 html, body {
   padding: 0;
   margin: 0;
-  background-color: #121212;
-  color: #e5e5e5;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-main);
 }
 
 a {
-  color: #8ab4f8;
+  color: var(--color-accent);
 }
 
-nav a {
-  color: #e5e5e5;
+.navbar {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  background-color: var(--color-nav-bg);
+}
+
+.navbar a {
+  color: var(--color-text);
   text-decoration: none;
+  transition: color 0.2s ease;
 }
 
-nav a:hover {
-  text-decoration: underline;
+.navbar a:hover {
+  color: var(--color-accent);
+}
+
+main {
+  padding: 1.5rem;
+}
+
+h1 {
+  color: var(--color-accent);
+}
+
+.card {
+  background: var(--color-card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.small {
+  color: var(--color-muted);
+  font-size: 0.75rem;
+}
+
+.btn {
+  background: var(--color-accent);
+  color: #0b0f0c;
+  border: 0;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.625rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid.two {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .grid.two {
+    grid-template-columns: 1fr 1fr;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,18 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body>
         <NavBar />
         {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 export default function Home() {
   return (
-    <main style={{ padding: 24 }}>
+    <main>
       <h1>BrickBox</h1>
       <p>Comic/Manga Collector hub — coming soon 🚀</p>
       <p>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -3,18 +3,15 @@ import Link from 'next/link';
 
 export default function NavBar() {
   return (
-    <nav
-      style={{
-        display: 'flex',
-        gap: 16,
-        padding: 16,
-        backgroundColor: '#1f1f1f',
-      }}
-    >
+    <nav className="navbar">
       <Link href="/">Home</Link>
       <Link href="/token">Token</Link>
       <Link href="/social">Social</Link>
-      <a href="https://brickbox.printify.me/" target="_blank" rel="noopener noreferrer">
+      <a
+        href="https://brickbox.printify.me/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Shop
       </a>
     </nav>


### PR DESCRIPTION
## Summary
- Load Roboto Mono via layout head for a modern, technical aesthetic
- Consolidate site styling with CSS variables and utility classes
- Refactor NavBar and homepage to use global styles instead of inline rules

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b02574c5d483288905fc3e296d76e7