### PR TITLE
style: modernize global styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,20 +1,33 @@
+/* app/globals.css */
+
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
 html, body {
-  padding: 0;
   margin: 0;
-  background-color: #121212;
-  color: #e5e5e5;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  padding: 0;
+  height: 100%;
+  color: #e1e1e1;
+  background: linear-gradient(145deg, #0d1117 0%, #1f1f1f 100%);
+  font-family: 'Poppins', sans-serif;
 }
 
 a {
-  color: #8ab4f8;
-}
-
-nav a {
-  color: #e5e5e5;
+  color: #e1e1e1;
   text-decoration: none;
+  transition: color 0.2s ease;
 }
 
-nav a:hover {
-  text-decoration: underline;
+a:hover {
+  color: #E0474C; /* Brick red accent for hover */
+}
+
+nav {
+  backdrop-filter: blur(10px);
+  background-color: rgba(31, 31, 31, 0.85);
+  border-bottom: 1px solid #272727;
+}
+
+section {
+  max-width: 960px;
+  margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- add Poppins font and dark gradient background to global styles
- refine link, nav, and section styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0253311d0832882623b476fb6cb0a