### PR TITLE
Handle missing Stripe signature in Cloudflare worker

### DIFF
--- a/worker-archive/worker.js
+++ b/worker-archive/worker.js
@@ -12,6 +12,9 @@ export default {
     }
 
     const sig = request.headers.get('stripe-signature');
+    if (!sig) {
+      return new Response('Missing stripe-signature header', { status: 400 });
+    }
     const payload = await request.text();
 
     try {
@@ -35,6 +38,9 @@ export default {
 }
 
 function parseStripeSignature(header) {
+  if (!header) {
+    throw new Error('Missing Stripe signature header');
+  }
   const parts = header.split(',');
   const timestampPart = parts.find(p => p.startsWith('t='));
   const sigPart = parts.find(p => p.startsWith('v1='));


### PR DESCRIPTION
## Summary
- safeguard Cloudflare worker against requests missing the `stripe-signature` header
- validate Stripe signature header before parsing

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b063ae29e083288041da9745cbbe35