### PR TITLE
Relax CSP to allow framing on BrickBox

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,10 +2,10 @@ const securityHeaders = [
   {
     key: 'Content-Security-Policy',
     value:
-      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self';",
+      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-ancestors 'self'; form-action 'self'; base-uri 'self';",
   },
   { key: 'Referrer-Policy', value: 'origin-when-cross-origin' },
-  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
   {


### PR DESCRIPTION
## Summary
- allow the site to render inside frames or in-app browsers by relaxing the security headers
- set `frame-ancestors` to `self` and `X-Frame-Options` to `SAMEORIGIN`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09efaf9a083289b489c9edc00e7b2