### PR TITLE
chore: format code with prettier

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,9 @@
-import './globals.css';
-import NavBar from '../components/NavBar';
+import "./globals.css";
+import NavBar from "../components/NavBar";
 
 export const metadata = {
-  title: 'BrickBox',
-  description: 'Comic/Manga Collector hub — coming soon 🚀',
+  title: "BrickBox",
+  description: "Comic/Manga Collector hub — coming soon 🚀",
 };
 
 export default function RootLayout({

--- a/app/perks/page.tsx
+++ b/app/perks/page.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useCallback, useEffect, useState } from 'react';
-import { PhantomConnect } from '../../components/wallet/PhantomConnect';
-import { hasMint } from '../../lib/solana';
-import { bbxMetadata } from '../token/metadata';
+import { useCallback, useEffect, useState } from "react";
+import { PhantomConnect } from "../../components/wallet/PhantomConnect";
+import { hasMint } from "../../lib/solana";
+import { bbxMetadata } from "../token/metadata";
 
 const MINT = bbxMetadata.mint;
 
@@ -28,13 +28,19 @@ export default function PerksPage() {
   return (
     <div className="card">
       <h2>Perks (Token-gated)</h2>
-      <div style={{display:'flex', gap:12, alignItems:'center', marginTop: 8}}>
+      <div
+        style={{ display: "flex", gap: 12, alignItems: "center", marginTop: 8 }}
+      >
         <PhantomConnect onConnected={onConnected} />
       </div>
-      {pubkey && <div className="small" style={{marginTop:8}}>Checking holdings on-chain…</div>}
+      {pubkey && (
+        <div className="small" style={{ marginTop: 8 }}>
+          Checking holdings on-chain…
+        </div>
+      )}
       {checking && <div className="small">Verifying BRICK balance…</div>}
       {isHolder === true && (
-        <div style={{marginTop:12}}>
+        <div style={{ marginTop: 12 }}>
           <div className="card">
             <h3>Welcome, BRICK Holder!</h3>
             <ul>
@@ -46,14 +52,15 @@ export default function PerksPage() {
         </div>
       )}
       {isHolder === false && (
-        <div style={{marginTop:12}}>
+        <div style={{ marginTop: 12 }}>
           <div className="card">
             <h3>Perks locked</h3>
-            <p className="small">You’ll need at least 1 BRICK to unlock these.</p>
+            <p className="small">
+              You’ll need at least 1 BRICK to unlock these.
+            </p>
           </div>
         </div>
       )}
     </div>
   );
 }
-

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,13 +1,13 @@
 "use client";
-import Link from 'next/link';
+import Link from "next/link";
 
 export default function NavBar() {
   return (
     <nav>
       <Link href="/">Home</Link>
       <Link href="/token">Token</Link>
-  <Link href="/live">Live</Link>
-  <Link href="/social">Social</Link>
+      <Link href="/live">Live</Link>
+      <Link href="/social">Social</Link>
       <a
         href="https://brickbox.printify.me"
         target="_blank"
@@ -18,4 +18,3 @@ export default function NavBar() {
     </nav>
   );
 }
-

--- a/components/wallet/PhantomConnect.tsx
+++ b/components/wallet/PhantomConnect.tsx
@@ -1,12 +1,18 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 
 declare global {
-  interface Window { solana?: any; }
+  interface Window {
+    solana?: any;
+  }
 }
 
-export function PhantomConnect({ onConnected }: { onConnected: (pubkey: string) => void }) {
+export function PhantomConnect({
+  onConnected,
+}: {
+  onConnected: (pubkey: string) => void;
+}) {
   const [hasPhantom, setHasPhantom] = useState(false);
   const [pubkey, setPubkey] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
@@ -14,13 +20,16 @@ export function PhantomConnect({ onConnected }: { onConnected: (pubkey: string) 
   useEffect(() => {
     setHasPhantom(!!window.solana?.isPhantom);
     if (window.solana?.isPhantom) {
-      window.solana.connect({ onlyIfTrusted: true }).then((res: any) => {
-        if (res?.publicKey) {
-          const key = String(res.publicKey.toString());
-          setPubkey(key);
-          onConnected(key);
-        }
-      }).catch(()=>{});
+      window.solana
+        .connect({ onlyIfTrusted: true })
+        .then((res: any) => {
+          if (res?.publicKey) {
+            const key = String(res.publicKey.toString());
+            setPubkey(key);
+            onConnected(key);
+          }
+        })
+        .catch(() => {});
     }
   }, [onConnected]);
 
@@ -33,7 +42,7 @@ export function PhantomConnect({ onConnected }: { onConnected: (pubkey: string) 
       onConnected(key);
     } catch (e) {
       console.error(e);
-      alert('Could not connect to Phantom.');
+      alert("Could not connect to Phantom.");
     } finally {
       setConnecting(false);
     }
@@ -41,14 +50,27 @@ export function PhantomConnect({ onConnected }: { onConnected: (pubkey: string) 
 
   if (!hasPhantom) {
     return (
-      <a className="btn" href="https://phantom.app/download" target="_blank" rel="noreferrer">
+      <a
+        className="btn"
+        href="https://phantom.app/download"
+        target="_blank"
+        rel="noreferrer"
+      >
         Install Phantom
       </a>
     );
   }
 
-  if (pubkey) return <span className="small">Wallet: {pubkey.slice(0,4)}…{pubkey.slice(-4)}</span>;
+  if (pubkey)
+    return (
+      <span className="small">
+        Wallet: {pubkey.slice(0, 4)}…{pubkey.slice(-4)}
+      </span>
+    );
 
-  return <button className="btn" onClick={connectNow} disabled={connecting}>{connecting ? 'Connecting…' : 'Connect Phantom'}</button>;
+  return (
+    <button className="btn" onClick={connectNow} disabled={connecting}>
+      {connecting ? "Connecting…" : "Connect Phantom"}
+    </button>
+  );
 }
-

--- a/lib/solana.ts
+++ b/lib/solana.ts
@@ -1,8 +1,9 @@
-import { Connection, PublicKey } from '@solana/web3.js';
+import { Connection, PublicKey } from "@solana/web3.js";
 
 export function getConnection() {
-  const endpoint = process.env.NEXT_PUBLIC_SOLANA_RPC || 'https://api.mainnet-beta.solana.com';
-  return new Connection(endpoint, 'confirmed');
+  const endpoint =
+    process.env.NEXT_PUBLIC_SOLANA_RPC || "https://api.mainnet-beta.solana.com";
+  return new Connection(endpoint, "confirmed");
 }
 
 export async function hasMint(owner: string, mint: string): Promise<boolean> {
@@ -10,7 +11,9 @@ export async function hasMint(owner: string, mint: string): Promise<boolean> {
     const connection = getConnection();
     const ownerPk = new PublicKey(owner);
     const mintPk = new PublicKey(mint);
-    const resp = await connection.getParsedTokenAccountsByOwner(ownerPk, { mint: mintPk });
+    const resp = await connection.getParsedTokenAccountsByOwner(ownerPk, {
+      mint: mintPk,
+    });
     for (const acc of resp.value) {
       const info: any = acc.account.data.parsed.info;
       const amount = info.tokenAmount?.uiAmount || 0;
@@ -18,7 +21,7 @@ export async function hasMint(owner: string, mint: string): Promise<boolean> {
     }
     return false;
   } catch (e) {
-    console.error('hasMint error', e);
+    console.error("hasMint error", e);
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- format navigation and wallet components with Prettier for consistent style
- tidy layout, perks page, and Solana helper module

## Testing
- `npm test`
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0b8319844832890603173b9b8c8e0