### PR TITLE
feat: add copy field component

### DIFF
--- a/components/CopyField.tsx
+++ b/components/CopyField.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useState } from "react";
+
+export default function CopyField({
+  label,
+  value,
+  mono = true,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const doCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value || "");
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="text-sm opacity-80">{label}</div>
+      <div className="flex gap-2">
+        <input
+          readOnly
+          value={value || ""}
+          className={`flex-1 p-3 rounded bg-bbxDark border border-bbxCream text-bbxCream ${
+            mono ? "font-mono text-sm" : ""
+          }`}
+        />
+        <button
+          onClick={doCopy}
+          className="px-3 py-2 rounded bg-bbxRed text-bbxCream whitespace-nowrap"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add CopyField component with copy-to-clipboard behavior and optional mono styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Can't resolve 'stripe')*

------
https://chatgpt.com/codex/tasks/task_e_68b0d7402b588328b75b383b8b570bed