### PR TITLE
Add Wallet and Account links to NavBar

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -15,6 +15,8 @@ export default function NavBar() {
         <li><Link href="/token">Token</Link></li>
         <li><Link href="/products">Store</Link></li>
         <li><Link href="/pricing">Pricing</Link></li>
+        <li><Link href="/wallet">Wallet</Link></li>
+        <li><Link href="/account">Account</Link></li>
         <li><Link href="/contact">Contact</Link></li>
         <li><Link href="/legal/terms">Terms</Link></li>
         <li><Link href="/legal/privacy">Privacy</Link></li>


### PR DESCRIPTION
## Summary
- include Wallet and Account links in NavBar so users can reach wallet and account pages directly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0d7880b2c83288bb85923661a2cc0