### PR TITLE
feat: add billing management link to pricing page

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -76,6 +76,9 @@ export default function PricingPage(){
       </div>
 
       <RefundNote />
+      <div className="text-center">
+        <a href="/account" className="underline opacity-90">Already subscribed? Manage billing</a>
+      </div>
       <p className="text-xs opacity-70 text-center">
         By subscribing you agree to our <a className="underline" href="/legal/terms">Terms</a> and <a className="underline" href="/legal/privacy">Privacy Policy</a>.
       </p>


### PR DESCRIPTION
## Summary
- add link for existing subscribers to manage billing on pricing page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0d7a398a48328aa616d25bc582f78