### PR TITLE
feat: add billing management button

### DIFF
--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -3,6 +3,9 @@ export default function SuccessPage(){
     <section className="max-w-xl mx-auto text-center space-y-4">
       <h1 className="text-3xl font-bold">You’re in! 🎉</h1>
       <p>Thanks for subscribing to BrickBox. Check your email for the receipt and details.</p>
+      <a href="/account" className="inline-block bg-bbxCream text-bbxDark px-4 py-2 rounded">
+        Manage Billing
+      </a>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add a Manage Billing button to the post-purchase success page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0d7bda4ac83289464deb9a2642151