### PR TITLE
Handle Stripe secret key at request time

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2023-10-16" });
-
 export async function POST(req: Request) {
   try {
     const { plan, email } = await req.json();
@@ -12,6 +10,12 @@ export async function POST(req: Request) {
 
     const priceId = plan === "yearly" ? process.env.STRIPE_PRICE_YEARLY : process.env.STRIPE_PRICE_MONTHLY;
     if (!priceId) return NextResponse.json({ error: "Missing price" }, { status: 500 });
+
+    const secretKey = process.env.STRIPE_SECRET_KEY;
+    if (!secretKey) {
+      return NextResponse.json({ error: "STRIPE_SECRET_KEY not configured" }, { status: 500 });
+    }
+    const stripe = new Stripe(secretKey, { apiVersion: "2023-10-16" });
 
     const siteUrl = process.env.SITE_URL || "http://localhost:3000";
     const session = await stripe.checkout.sessions.create({

--- a/app/api/portal/route.ts
+++ b/app/api/portal/route.ts
@@ -1,14 +1,18 @@
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2023-10-16" });
-
 export async function POST(req: Request) {
   try {
     const { email } = await req.json();
     if (!email) {
       return NextResponse.json({ error: "Missing email" }, { status: 400 });
     }
+
+    const secretKey = process.env.STRIPE_SECRET_KEY;
+    if (!secretKey) {
+      return NextResponse.json({ error: "STRIPE_SECRET_KEY not configured" }, { status: 500 });
+    }
+    const stripe = new Stripe(secretKey, { apiVersion: "2023-10-16" });
 
     // Find (or narrow to the first) customer by email
     const list = await stripe.customers.list({ email, limit: 1 });


### PR DESCRIPTION
## Summary
- Instantiate Stripe client inside API route handlers
- Return 500 responses when STRIPE_SECRET_KEY is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b232cb8e2483288cf38789a3fc020a